### PR TITLE
Adding stuff to make trivially_copyable permiate if possible

### DIFF
--- a/include/tao/tuple/tuple.hpp
+++ b/include/tao/tuple/tuple.hpp
@@ -189,8 +189,14 @@ namespace tao
 
          tuple_value( const tuple_value& ) = default;
          tuple_value( tuple_value&& ) = default;
+         tuple_value& operator=( tuple_value const& ) = default;
+         tuple_value& operator=( tuple_value && ) = default;
 
-         template< typename U >
+         template< typename U,
+             typename=impl::enable_if_t<
+                 !std::is_same<typename std::decay<U>::type,tuple_value>::value
+             >
+         >
          TAO_TUPLE_CUDA_ANNOTATE_COMMON tuple_value& operator=( U&& v ) noexcept( std::is_nothrow_assignable< T&, U >::value )
          {
             value = std::forward< U >( v );
@@ -332,28 +338,8 @@ namespace tao
 
          tuple_base( const tuple_base& ) = default;
          tuple_base( tuple_base&& ) = default;
-
-         TAO_TUPLE_CUDA_ANNOTATE_COMMON
-         tuple_base& operator=( const tuple_base& v ) noexcept( seq::is_all< std::is_nothrow_copy_assignable< Ts >::value... >::value )
-         {
-#ifdef TAO_SEQ_FOLD_EXPRESSIONS
-            ( tuple_value< Is, Ts >::operator=( static_cast< tuple_value< Is, Ts >& >( v ).get() ), ... );
-#else
-            (void)swallow{ ( tuple_value< Is, Ts >::operator=( static_cast< tuple_value< Is, Ts >& >( v ).get() ), true )..., true };
-#endif
-            return *this;
-         }
-
-         TAO_TUPLE_CUDA_ANNOTATE_COMMON
-         tuple_base& operator=( tuple_base&& v ) noexcept( seq::is_all< std::is_nothrow_move_assignable< Ts >::value... >::value )
-         {
-#ifdef TAO_SEQ_FOLD_EXPRESSIONS
-            ( tuple_value< Is, Ts >::operator=( std::forward< Ts >( static_cast< tuple_value< Is, Ts >& >( v ).get() ) ), ... );
-#else
-            (void)swallow{ ( tuple_value< Is, Ts >::operator=( static_cast< tuple_value< Is, Ts >& >( v ) ), true )..., true };
-#endif
-            return *this;
-         }
+         tuple_base& operator=( const tuple_base& v ) = default;
+         tuple_base& operator=( tuple_base&& v ) = default;
 
          template< typename... Us >
          TAO_TUPLE_CUDA_ANNOTATE_COMMON tuple_base& operator=( const tuple< Us... >& v ) noexcept( seq::is_all< std::is_nothrow_assignable< Ts&, const Us& >::value... >::value )

--- a/src/test/tuple/tuple_main.cpp
+++ b/src/test/tuple/tuple_main.cpp
@@ -20,6 +20,10 @@ int main()
    static_assert( tuple_size< decltype( t ) >::value == 3, "oops" );
    static_assert( tuple_size< decltype( t2 ) >::value == 3, "oops" );
    static_assert( tuple_size< decltype( t3 ) >::value == 3, "oops" );
+#ifndef _MSC_VER // Known failure on Microsoft compiler
+   static_assert(std::is_trivially_copyable<tuple<int>>::value, "");
+#endif
+   static_assert(std::is_trivially_destructible<tuple<int>>::value, "");
 
    assert( get< 0 >( t2 ) == 1 );
    assert( get< 1 >( t2 ) == 2 );


### PR DESCRIPTION
Currently, the tuple isn't trivially_copyable even if all of its types are.....

This patch enables that.....

One thing that I am not sure how to test is if the CUDA stuff still works, seeing as I had to remove some of the CUDA directives in order to add this....