### PR TITLE
Fixing problem with default operator=

### DIFF
--- a/include/tao/tuple/tuple.hpp
+++ b/include/tao/tuple/tuple.hpp
@@ -283,6 +283,8 @@ namespace tao
 
          tuple_value( const tuple_value& ) = default;
          tuple_value( tuple_value&& ) = default;
+         tuple_value& operator=( tuple_value const& ) = default;
+         tuple_value& operator=( tuple_value && ) = default;
 
          template< typename U >
          TAO_TUPLE_CUDA_ANNOTATE_COMMON tuple_value& operator=( U&& v ) noexcept( std::is_nothrow_assignable< T&, U >::value )
@@ -422,6 +424,8 @@ namespace tao
 
       tuple( const tuple& ) = default;
       tuple( tuple&& ) = default;
+      tuple& operator=( tuple const& ) = default;
+      tuple& operator=( tuple && ) = default;
 
       TAO_TUPLE_SUPPRESS_NVCC_HD_WARN
       template< typename... Us,

--- a/src/test/tuple/tuple_main.cpp
+++ b/src/test/tuple/tuple_main.cpp
@@ -25,6 +25,19 @@ int main()
 #endif
    static_assert(std::is_trivially_destructible<tuple<int>>::value, "");
 
+   struct composite
+   {
+       tuple<int, double, int> inner;
+   };
+
+   composite t6;
+   composite t7;
+
+   // Just check for the existence of these (if they exist they are compiler
+   // generated and should work correctly)
+   t6 = t7;
+   t6 = std::move(t7);
+
    assert( get< 0 >( t2 ) == 1 );
    assert( get< 1 >( t2 ) == 2 );
    assert( get< 2 >( t2 ) == 3 );


### PR DESCRIPTION
If you have a composite struct like so:

    struct test
    {
        tuple<int, float, double> inner;
    };

The rule of 0 fails, because the default operator= is not generated